### PR TITLE
Enhance CLI functionality by adding support for extracting a public key from an existing JWK file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # create arweave wallet file
 
-A command line program that creates a wallet json file.
+A command line program that supports the following:
+- creates a new arweave wallet json and prints to stdout
+- parses an existing wallet json file and returns the pubkey

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # create arweave wallet file
 
 A command line program that supports the following:
-- creates a new arweave wallet json and prints to stdout
-- parses an existing wallet json file and returns the pubkey
+- creates a new arweave wallet json and prints to stdout `node index.js`
+- parses an existing wallet json file and returns the pubkey `node index.js -f <path-to-wallet.json>`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
-# create arweave wallet file
+# Create arweave wallet file
 
 A command line program that supports the following:
-- creates a new arweave wallet json and prints to stdout `node index.js`
-- parses an existing wallet json file and returns the pubkey `node index.js -f <path-to-wallet.json>`
+- creates a new arweave wallet json and prints to stdout
+- parses an existing wallet json file and returns the pubkey
+
+## Usage
+
+```bash
+node index.js
+node index.js pubkey -f <path-to-wallet.json>
+```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,38 @@
 #!/usr/bin/env node
 
-require('arweave').init({}).wallets.generate().then(JSON.stringify).then(console.log.bind(console))
+const fs = require('fs');
+const { init } = require('arweave');
+
+const arweave = init({});
+const args = process.argv.slice(2);
+
+if (args.length > 0) {
+  if (args[0] === 'pubkey') {
+    if (args[1] !== '-f' || !args[2]) {
+      console.error('Error: Please specify a wallet file with "-f <path-to-wallet.json>".');
+      process.exit(1);
+    }
+    
+    // Read and parse the JWK file, then get its address
+    fs.promises.readFile(args[2], 'utf8')
+      .then(JSON.parse)
+      .then(jwk => arweave.wallets.jwkToAddress(jwk))
+      .then(console.log)
+      .catch(error => {
+        console.error('Error:', error.message);
+        process.exit(1);
+      });
+  } else {
+    console.error('Error: Unknown command. Use "pubkey -f <path-to-wallet.json>" or run without arguments to generate a new wallet.');
+    process.exit(1);
+  }
+} else {
+  // Default behavior: Generate a new wallet
+  arweave.wallets.generate()
+    .then(JSON.stringify)
+    .then(console.log)
+    .catch(error => {
+      console.error('Error:', error.message);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
### Add CLI support for extracting public key from existing JWK file

This PR enhances CLI functionality by adding support for extracting a public key from an existing JWK file

#### **Changes:**
- **default behavior remains the same**: running `node index.js` generates a new wallet.
- **new feature**: `node index.js pubkey -f /path/to/wallet.json` extracts the public key.
- **error handling improvements**:
  - prevents running `pubkey` without `-f`.
  - displays usage errors for incorrect commands.
  - handles missing or unreadable JWK files gracefully.